### PR TITLE
v2016_09_22_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## `v2016_09_22_1`
+
+* ssh config to match the non LTS stack's (`StrictHostKeyChecking` disabled)
+* git config to match the non LTS stack's : email and name set to builds@bitrise.io / Bitrise Bot
+
+
+## `v2016_09_16_1`
+
+* `bitrise` (CLI): `1.4.0`
+
+
 ## `v2016_08_10_1`
 
 * `bitrise` (CLI): `1.3.7`

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,21 @@ FROM bitriseio/android-ndk:2016_05_26_1
 
 
 # ------------------------------------------------------
-# --- Install / update required tools
 
 RUN apt-get update -qq
+
+
+# ------------------------------------------------------
+# --- Git config
+
+# Git config
+RUN git config --global user.email builds@bitrise.io
+RUN git config --global user.name "Bitrise Bot"
+
+# ------------------------------------------------------
+# --- SSH config
+
+COPY ./ssh/config /root/.ssh/config
 
 
 # ------------------------------------------------------
@@ -30,5 +42,5 @@ RUN /root/.bitrise/tools/stepman update
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS v2016_08_10_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS v2016_09_22_1
 CMD bitrise --version

--- a/ssh/config
+++ b/ssh/config
@@ -1,0 +1,2 @@
+Host *
+    StrictHostKeyChecking no


### PR DESCRIPTION
* ssh config to match the non LTS stack's (`StrictHostKeyChecking` disabled)
* git config to match the non LTS stack's : email and name set to builds@bitrise.io / Bitrise Bot